### PR TITLE
Quixk Fix: Jetson Doc

### DIFF
--- a/src/index.rst
+++ b/src/index.rst
@@ -167,6 +167,7 @@ Run the **example scene recognition** code at the begining of this page to verif
    security/index
    backup/index
    using-deepstack-with-nvidia-gpus/index
+   nvidia-jetson/index
    raspberry-pi/index
    best-practices/index
    api-reference/index


### PR DESCRIPTION
This PR adds the Jetson page to the documentation's menu.